### PR TITLE
fix: Resolve SCSS and Angular configuration errors for TimelineComponent

### DIFF
--- a/src/app/timeline/timeline.module.ts
+++ b/src/app/timeline/timeline.module.ts
@@ -1,20 +1,22 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TimelineComponent } from './timeline/timeline.component'; // Added import
+// Removed import for TimelineComponent as it's now standalone
 
 import { TimelineRoutingModule } from './timeline-routing.module';
 
 
 @NgModule({
   declarations: [
-    TimelineComponent // Added component to declarations
+    // TimelineComponent removed from declarations
   ],
   imports: [
     CommonModule,
     TimelineRoutingModule
+    // If TimelineComponent were used in templates within this module (unlikely for routed components),
+    // it would be imported here: TimelineComponent
   ],
   exports: [
-    TimelineComponent // Added component to exports
+    // TimelineComponent removed from exports
   ]
 })
 export class TimelineModule { }

--- a/src/app/timeline/timeline/timeline.component.scss
+++ b/src/app/timeline/timeline/timeline.component.scss
@@ -307,4 +307,3 @@
 // to dynamically set light/dark text might be needed. For now, we assume
 // reasonable contrast or that users will pick good background colors.
 // The `color: #000;` on `.period-item h3` is a fallback.
-```

--- a/src/app/timeline/timeline/timeline.component.ts
+++ b/src/app/timeline/timeline/timeline.component.ts
@@ -1,11 +1,14 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common'; // Added
 import { TimelineService } from '../timeline.service';
 import { TimelineData, HistoricalPeriod, HistoricalEvent, ThematicGroup } from '../timeline.model';
 
 @Component({
   selector: 'app-timeline',
+  standalone: true, // Added
+  imports: [CommonModule], // Added
   templateUrl: './timeline.component.html',
-  styleUrls: ['./timeline.component.scss'] // Corrected to styleUrls and array
+  styleUrls: ['./timeline.component.scss']
 })
 export class TimelineComponent implements OnInit {
   periods: HistoricalPeriod[] = [];


### PR DESCRIPTION
This commit addresses issues identified after the initial implementation of the historical timeline component:

1.  **SCSS Syntax Error:**
    - Removed extraneous characters and error message fragments from the end of `timeline.component.scss` that were causing a parsing failure.

2.  **Angular Component Configuration:**
    - Modified `TimelineComponent` to be a standalone component (`standalone: true`).
    - Added `CommonModule` to the `imports` array of `TimelineComponent` to provide common directives and pipes used in its template.
    - Updated `TimelineModule` by removing `TimelineComponent` from its `declarations` and `exports` arrays, consistent with the component now being standalone.

These changes should resolve the build errors related to SCSS parsing and Angular compiler errors TS-996008 and TS-996004.