### PR TITLE
fix: Resolve issues with event image and modal visibility

### DIFF
--- a/src/app/timeline/timeline.service.ts
+++ b/src/app/timeline/timeline.service.ts
@@ -19,6 +19,7 @@ export class TimelineService {
         date: '0070-01-01',
         title: 'Colosseum Construction Begins',
         summary: 'Construction of the Flavian Amphitheatre (Colosseum) starts in Rome.',
+        imageUrl: 'https://via.placeholder.com/300x200.png?text=Colosseum', // Added
         periodId: 'p1',
         detailedDescription: 'The Colosseum, an iconic symbol of Imperial Rome, was built by the Flavian emperors as a gift to the Roman people. Its construction began under Vespasian in AD 72 and was completed in AD 80 under his successor and heir, Titus.',
         sources: [{ name: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Colosseum' }],
@@ -38,6 +39,7 @@ export class TimelineService {
         date: '1066-10-14',
         title: 'Battle of Hastings',
         summary: 'The Norman forces of William the Conqueror defeat the English forces of King Harold Godwinson.',
+        imageUrl: 'https://via.placeholder.com/300x200.png?text=Battle+of+Hastings', // Added
         periodId: 'p2',
         groupIds: ['g1'],
         detailedDescription: 'The Battle of Hastings was fought on 14 October 1066 between the Norman-French army of William, Duke of Normandy, and an English army under the Anglo-Saxon King Harold Godwinson, beginning the Norman conquest of England.',

--- a/src/app/timeline/timeline/timeline.component.html
+++ b/src/app/timeline/timeline/timeline.component.html
@@ -44,7 +44,7 @@
   <!-- Thematic Grouping: No explicit rendering in this step -->
 
   <!-- Detail View (Conditional Display) -->
-  <div class="event-detail-view" *ngIf="selectedEvent">
+  <div class="event-detail-view" *ngIf="selectedEvent" [class.visible]="selectedEvent">
     <button (click)="clearSelectedEvent()" class="close-button">Close</button>
     <h2>{{ selectedEvent.title }}</h2>
     <p class="event-detail-date">{{ selectedEvent.date | date:'fullDate' }}</p> <!-- Using fullDate for more detail -->


### PR DESCRIPTION
Addresses your feedback that event images were not showing and the detail modal was not appearing.

Fixes include:
1.  **Data Correction for Event Images:**
    - Ensured `HistoricalEvent` objects in mock data have a direct `imageUrl` property populated with valid placeholder URLs. The template was already expecting `event.imageUrl`.
2.  **Modal Visibility Transition:**
    - Updated `timeline.component.html` to correctly apply the `.visible` class to the `.event-detail-view` modal when an event is selected (i.e., `[class.visible]="selectedEvent"`). This enables the existing CSS transitions for opacity and transform, making the modal appear as intended.

Component logic for event selection and modal display (`*ngIf="selectedEvent"`) was reviewed and deemed correct. SCSS for image display was also confirmed to be appropriate.