### PR TITLE
I've refined the IntersectionObserver and added some debug styles to …

### DIFF
--- a/src/app/timeline/timeline/timeline.component.scss
+++ b/src/app/timeline/timeline/timeline.component.scss
@@ -248,8 +248,16 @@
 
   // Visible state for IntersectionObserver
   &.in-view {
-    // opacity: 1; // This would re-enable the reveal if base opacity was 0
-    // transform: translateY(0); // This would re-enable the reveal if base transform was different
+    opacity: 1 !important; // Ensure opacity is forced for debug
+    transform: translateY(0) !important; // Ensure transform is forced for debug
+    border: 5px solid limegreen !important; 
+    background-color: rgba(0, 255, 0, 0.1) !important; // Light green tint
+
+    // For even more aggressive debugging, ensure content is visible:
+    // .event-title, .event-date, .event-summary {
+    //   color: black !important;
+    //   background-color: yellow !important;
+    // }
   }
 
   .event-image {

--- a/src/app/timeline/timeline/timeline.component.ts
+++ b/src/app/timeline/timeline/timeline.component.ts
@@ -14,7 +14,7 @@ import { TimelineData, HistoricalPeriod, HistoricalEvent, ThematicGroup } from '
 })
 export class TimelineComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChildren('eventItemRef') eventItemRefs!: QueryList<ElementRef>;
-  // Removed @ViewChild for eventsContainerRef
+  @ViewChild('eventsContainerRef') eventsContainerRef!: ElementRef<HTMLDivElement>; // Re-added
   // Removed @ViewChild for scrollDotRef
   private observer!: IntersectionObserver;
   // Removed scrollListenerFn
@@ -74,7 +74,7 @@ export class TimelineComponent implements OnInit, AfterViewInit, OnDestroy {
   private initObserver(): void {
     // No need for isPlatformBrowser check here as it's called from a guarded block
     const options = {
-      root: document.querySelector('.events-container'),
+      root: this.eventsContainerRef.nativeElement, // Changed from document.querySelector
       rootMargin: '0px',
       threshold: 0.1
     };
@@ -82,6 +82,7 @@ export class TimelineComponent implements OnInit, AfterViewInit, OnDestroy {
     this.observer = new IntersectionObserver((entries, observer) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
+          console.log('Event item IS intersecting:', entry.target); // DEBUG LOG
           entry.target.classList.add('in-view');
           observer.unobserve(entry.target);
         }


### PR DESCRIPTION
…help with the event reveal.

Here's what I did to help diagnose why event items might not be appearing, which I suspect is related to the IntersectionObserver-based reveal animation:

- **TimelineComponent TypeScript:**
    - I restored `@ViewChild("eventsContainerRef")`.
    - I changed the `root` option for the IntersectionObserver in `initObserver()` to use `this.eventsContainerRef.nativeElement` for more reliable context.
    - I added a `console.log` statement within the observer callback to trace when items are detected as intersecting.
- **TimelineComponent SCSS:**
    - I added aggressive debug styles to the `.event-item.in-view` class (e.g., a bright lime green border and a light green background tint, using `!important`). This will make it visually obvious if the class is being correctly applied.
    - I ensured the base `.event-item` styles for the reveal animation (`opacity: 0`, `transform: translateY(40px)`) are active.

These changes aim to clarify whether the IntersectionObserver is correctly identifying visible event items and applying the `.in-view` class.