### PR TITLE
style: Change event card background to plain white

### DIFF
--- a/src/app/timeline/timeline/timeline.component.scss
+++ b/src/app/timeline/timeline/timeline.component.scss
@@ -5,8 +5,8 @@
   --primary-text-color: #3a3a3a; // dark brown/charcoal
   --secondary-text-color: #6c5f5b; // A slightly lighter, muted brown for secondary text
   --accent-color-gold: #d4af37; // gold
-  --card-background-color: #fffef7; // lighter parchment/off-white
-  --card-background-color-rgb: 255, 254, 247; // RGB version for opacity
+  --card-background-color: #ffffff; // plain white
+  --card-background-color-rgb: 255, 255, 255; // plain white RGB
   --border-color: #c8bba8; // muted gold/brown for borders
   --overlay-background: rgba(58, 44, 20, 0.7); // brownish overlay
   --shadow-color: rgba(58, 44, 20, 0.15); // Shadow color to match the theme


### PR DESCRIPTION
Updates the theme to use a plain white background for event cards and other elements styled with --card-background-color.

- Modified `--card-background-color` in `timeline.component.scss` from `#fffef7` (parchment/off-white) to `#ffffff` (plain white).
- Updated the corresponding `--card-background-color-rgb` variable as well.